### PR TITLE
AM-493: Monkey patch Util::Forwardable to work with Ruby 3 kwargs

### DIFF
--- a/lib/cequel/util.rb
+++ b/lib/cequel/util.rb
@@ -66,8 +66,8 @@ module Cequel
       include ::Forwardable
 
       def delegate(*args, &block)
-        return super if args.one?
-        Module.instance_method(:delegate).bind(self).call(*args, &block)
+        kwargs = args.pop if args.last.is_a? Hash # pull off the hash that is the last argument
+        Module.instance_method(:delegate).bind(self).call(*args, **kwargs, &block)
       end
     end
   end

--- a/spec/examples/spec_helper.rb
+++ b/spec/examples/spec_helper.rb
@@ -11,24 +11,6 @@ Dir.glob(File.expand_path('../../shared/**/*.rb', __FILE__)).each do |file|
   require file
 end
 
-
-KNOWN_WARNING_FRAGMENTS = [
-]
-
-KNOWN_WARNING_PATHS = [
-]
-
-# Set this to true during blocks where we want to raise errors.
-$ruby_3_warnings_as_errors = false
-
-def Warning.warn(message)
-  should_raise = $ruby_3_warnings_as_errors
-  should_raise = false if KNOWN_WARNING_FRAGMENTS.any? { |fragment| message.include?(fragment) }
-  paths = caller.join('')
-  should_raise = false if KNOWN_WARNING_PATHS.any? { |path_fragment| paths.include?(path_fragment) }
-  raise "[RUBY 3 DEPRECATION] #{message}" if should_raise
-end
-
 RSpec.configure do |config|
   config.include(Cequel::SpecSupport::Helpers)
   config.extend(Cequel::SpecSupport::Macros)
@@ -67,13 +49,6 @@ RSpec.configure do |config|
 
   config.verbose_retry = true
   config.default_retry_count = 0
-
-  config.around(:each) do |example|
-    $ruby_3_warnings_as_errors = true
-    example.run
-  ensure
-    $ruby_3_warnings_as_errors = false
-  end
 end
 
 if defined? byebug

--- a/spec/examples/util_spec.rb
+++ b/spec/examples/util_spec.rb
@@ -1,0 +1,124 @@
+# -*- encoding : utf-8 -*-
+require_relative 'spec_helper'
+require 'forwardable'
+require_relative '../../lib/cequel/util'
+
+describe Cequel::Util do
+  let(:test_klass) do
+    module ActiveSupportAbbreviated
+      # refine so that we don't monkey patch this for the whole test suite
+      refine Module do
+        # matches method signature for ActiveSupport.delegate
+        # abbreviated form of that method with most options removed for brevity
+        # https://github.com/rails/rails/blob/a19b13b61f7af612569943ec7d536185cbec875c/activesupport/lib/active_support/core_ext/module/delegation.rb#L171
+        def delegate(*methods, to: nil, prefix: nil, allow_nil: nil, private: nil)
+          unless to
+            raise ArgumentError, "Delegation needs a target. Supply a keyword argument 'to' (e.g. delegate :hello, to: :greeter)."
+          end
+    
+          location = caller_locations(1, 1).first
+          file, line = location.path, location.lineno
+    
+          receiver = to.to_s
+    
+          method_def = []
+          method_names = []
+    
+          methods.each do |method|
+            method_name = prefix ? "#{method_prefix}#{method}" : method
+            method_names << method_name.to_sym
+    
+            # Attribute writer methods only accept one argument. Makes sure []=
+            # methods still accept two arguments.
+            definition = \
+              if /[^\]]=\z/.match?(method)
+                "arg"
+              else
+                method_object =
+                  begin
+                    if to.is_a?(Module)
+                      to.method(method)
+                    elsif receiver == "self.class"
+                      method(method)
+                    end
+                  rescue NameError
+                    # Do nothing. Fall back to `"..."`
+                  end
+    
+                if method_object
+                  parameters = method_object.parameters
+    
+                  if (parameters.map(&:first) & [:opt, :rest, :keyreq, :key, :keyrest]).any?
+                    "..."
+                  else
+                    defn = parameters.filter_map { |type, arg| arg if type == :req }
+                    defn << "&block"
+                    defn.join(", ")
+                  end
+                else
+                  "..."
+                end
+              end
+    
+            # The following generated method calls the target exactly once, storing
+            # the returned value in a dummy variable.
+            #
+            # Reason is twofold: On one hand doing less calls is in general better.
+            # On the other hand it could be that the target has side-effects,
+            # whereas conceptually, from the user point of view, the delegator should
+            # be doing one call.
+            method = method.to_s
+            method_name = method_name.to_s
+    
+            method_def <<
+              "def #{method_name}(#{definition})" <<
+              "  _ = #{receiver}" <<
+              "  _.#{method}(#{definition})" <<
+              "rescue NoMethodError => e" <<
+              "  if _.nil? && e.name == :#{method}" <<
+              %(   raise DelegationError, "#{self}##{method_name} delegated to #{receiver}.#{method}, but #{receiver} is nil: \#{self.inspect}") <<
+              "  else" <<
+              "    raise" <<
+              "  end" <<
+              "end"
+          end
+          module_eval(method_def.join(";"), file, line)
+          method_names
+        end
+      end
+    end
+
+    Class.new do
+      include ActiveSupportAbbreviated
+      extend ::Cequel::Util::Forwardable
+
+      attr_reader :queue
+
+      def initialize
+        @queue = []    # prepare delegate object
+      end
+
+      # setup preferred interface, enqueue() and dequeue()...
+      # Forwardable#def_delegator
+      def_delegator :@queue, :push, :enqueue
+
+      # ActiveSupport.delegate
+      delegate :shift, to: :@queue, allow_nil: true
+      alias :dequeue :shift
+    end
+  end
+
+  subject { test_klass.new }
+
+  it "successfully uses Forwardable's def_delegator method" do
+    allow(subject.queue).to receive(:push).and_call_original
+    expect(subject.enqueue(1)).to eq([1])
+    expect(subject.queue).to have_received(:push)
+  end
+
+  it "successfully uses ActiveSupport's delegate method" do
+    allow(subject.queue).to receive(:shift).and_call_original
+    expect(subject.dequeue).to eq(nil)
+    expect(subject.queue).to have_received(:shift)
+  end
+end


### PR DESCRIPTION
[Jira ticket](https://convertkit.atlassian.net/browse/AM-493)

Cequel is trying to work around the potential that ActiveSupport's Module.delegate monkey patch exists. It reset's Forwardable's delegate method to use ActiveSupport's delegate method definition.

But with Ruby 3 no longer handling mixed positional and keyword args, this monkey patch no longer works. We've updated in our fork to handle the kwargs.

The only Forwardable methods that Cequel uses are `def_delegator` and `def_delegators` (this is why the reset `delegate` back to ActiveSupports definition). These methods **do not call** `delegate` under the hood.

I turned on our little warning hack to make sure that my fix worked as expected when running the specs. I can remove if we don't want that to persist in our fork.

In the specs, you'll notice that my `test_klass` only refines the `Module` class. If I monkey patch `Module` in my test, it's monkey patched in the whole suite and things go cray cray. A refinement should behave the same and still give us the confidence we need.

After this is merged, we'll need to update the commit SHA ref in our main app's `Gemfile`.

